### PR TITLE
Add MeterBar component

### DIFF
--- a/frontend/src/components/MeterBar.tsx
+++ b/frontend/src/components/MeterBar.tsx
@@ -4,14 +4,17 @@ import clsx from "clsx";
 function getNumbersPercentageOfSum(
 	numbers: number[],
 	decimalPlaces: number = 2
-): number[] {
+): [number[], number] {
 	let total = 0;
 	for (const number of numbers) {
 		total += number;
 	}
-	return numbers.map((number) =>
-		Number(((number / total) * 100).toFixed(decimalPlaces))
-	);
+	return [
+		numbers.map((number) =>
+			Number(((number / total) * 100).toFixed(decimalPlaces))
+		),
+		Number(total.toFixed(decimalPlaces)),
+	];
 }
 
 function getContrastText(background: [number, number, number]) {
@@ -38,6 +41,7 @@ interface MeterBarProps {
 	label: string;
 	sections: MeterBarSection[];
 	renderExtendedText?: (amount: number) => string;
+	renderTotalAmountText?: (amount: number) => string;
 }
 
 export function MeterBar({
@@ -45,8 +49,9 @@ export function MeterBar({
 	className,
 	renderExtendedText,
 	label,
+	renderTotalAmountText,
 }: MeterBarProps) {
-	const percentages = getNumbersPercentageOfSum(
+	const [percentages, total] = getNumbersPercentageOfSum(
 		sections.map((section) => section.amount),
 		2
 	);
@@ -64,7 +69,13 @@ export function MeterBar({
 	return (
 		<div className={clsx("MicroMeterBar w-full flex flex-col", className)}>
 			<div className="px-20 flex">
-				<Typography largeness="large">{label}</Typography>
+				<Typography largeness="large">
+					{label} (
+					{renderTotalAmountText
+						? renderTotalAmountText(total)
+						: `Out of ${total}`}
+					)
+				</Typography>
 				<legend className="ml-auto flex space-x-12">
 					{parsedSections.map((section, i) => (
 						<span

--- a/frontend/src/components/MeterBar.tsx
+++ b/frontend/src/components/MeterBar.tsx
@@ -32,7 +32,7 @@ function getContrastText(background: [number, number, number]) {
 interface MeterBarSection {
 	label: string;
 	amount: number;
-	renderExtendedText?: (amount: number) => string;
+	renderSectionAmount?: (amount: number) => string;
 	colour: [number, number, number];
 }
 
@@ -40,18 +40,20 @@ interface MeterBarProps {
 	className?: string;
 	label: string;
 	sections: MeterBarSection[];
-	showTotalText?: boolean;
-	renderExtendedText?: (amount: number) => string;
-	renderTotalText?: (amount: number) => string;
+	showTotal?: boolean;
+	showAmounts?: boolean;
+	renderSectionAmount?: (amount: number) => string;
+	renderTotal?: (amount: number) => string;
 }
 
 export function MeterBar({
 	sections,
 	className,
-	renderExtendedText,
+	renderSectionAmount,
 	label,
-	renderTotalText,
-	showTotalText = false,
+	renderTotal,
+	showTotal,
+	showAmounts,
 }: MeterBarProps) {
 	const [percentages, total] = getNumbersPercentageOfSum(
 		sections.map((section) => section.amount),
@@ -62,7 +64,7 @@ export function MeterBar({
 		.map((section, i) => ({
 			backgroundColour: section.colour,
 			percentage: percentages[i],
-			renderExtendedText: section.renderExtendedText,
+			renderSectionAmount: section.renderSectionAmount,
 			label: section.label,
 			amount: section.amount,
 		}))
@@ -72,11 +74,12 @@ export function MeterBar({
 		<div className={clsx("MicroMeterBar w-full flex flex-col", className)}>
 			<div className="px-20 flex">
 				<Typography largeness="large">
-					{label} (
-					{showTotalText && renderTotalText
-						? renderTotalText(total)
-						: `Out of ${total}`}
-					)
+					{label}
+					{showTotal &&
+						" " +
+							(renderTotal
+								? renderTotal(total)
+								: `(Out of ${total})`)}
 				</Typography>
 				<legend className="ml-auto flex space-x-12">
 					{parsedSections.map((section, i) => (
@@ -111,12 +114,15 @@ export function MeterBar({
 							color: getContrastText(section.backgroundColour),
 						}}>
 						{`${section.percentage}%`}
-						{section.percentage > 30 &&
+						{showAmounts &&
+							section.percentage > 30 &&
 							` (${
-								section.renderExtendedText
-									? section.renderExtendedText(section.amount)
-									: renderExtendedText
-									? renderExtendedText(section.amount)
+								section.renderSectionAmount
+									? section.renderSectionAmount(
+											section.amount
+									  )
+									: renderSectionAmount
+									? renderSectionAmount(section.amount)
 									: section.amount
 							})`}
 					</span>

--- a/frontend/src/components/MeterBar.tsx
+++ b/frontend/src/components/MeterBar.tsx
@@ -40,8 +40,9 @@ interface MeterBarProps {
 	className?: string;
 	label: string;
 	sections: MeterBarSection[];
+	showTotalText?: boolean;
 	renderExtendedText?: (amount: number) => string;
-	renderTotalAmountText?: (amount: number) => string;
+	renderTotalText?: (amount: number) => string;
 }
 
 export function MeterBar({
@@ -49,7 +50,8 @@ export function MeterBar({
 	className,
 	renderExtendedText,
 	label,
-	renderTotalAmountText,
+	renderTotalText,
+	showTotalText = false,
 }: MeterBarProps) {
 	const [percentages, total] = getNumbersPercentageOfSum(
 		sections.map((section) => section.amount),
@@ -71,8 +73,8 @@ export function MeterBar({
 			<div className="px-20 flex">
 				<Typography largeness="large">
 					{label} (
-					{renderTotalAmountText
-						? renderTotalAmountText(total)
+					{showTotalText && renderTotalText
+						? renderTotalText(total)
 						: `Out of ${total}`}
 					)
 				</Typography>

--- a/frontend/src/components/MeterBar.tsx
+++ b/frontend/src/components/MeterBar.tsx
@@ -1,3 +1,4 @@
+import { Typography } from ".";
 import clsx from "clsx";
 
 function getNumbersPercentageOfSum(
@@ -63,10 +64,10 @@ export function MeterBar({
 	return (
 		<div className={clsx("MicroMeterBar w-full flex flex-col", className)}>
 			<div className="px-20 flex">
-				<h4 className="text-text dark:text-text-d">{label}</h4>
+				<Typography largeness="large">{label}</Typography>
 				<legend className="ml-auto flex space-x-12">
 					{parsedSections.map((section) => (
-						<span className="text-text dark:text-text-d flex items-center">
+						<span className="flex items-center">
 							<svg width="10" height="10" className="mr-2">
 								<rect
 									width="10"
@@ -78,7 +79,7 @@ export function MeterBar({
 									}}
 								/>
 							</svg>
-							{section.label}
+							<Typography>{section.label}</Typography>
 						</span>
 					))}
 				</legend>

--- a/frontend/src/components/MeterBar.tsx
+++ b/frontend/src/components/MeterBar.tsx
@@ -1,0 +1,110 @@
+import clsx from "clsx";
+
+function getNumbersPercentageOfSum(
+	numbers: number[],
+	decimalPlaces: number = 2
+): number[] {
+	let total = 0;
+	for (const number of numbers) {
+		total += number;
+	}
+	return numbers.map((number) =>
+		Number(((number / total) * 100).toFixed(decimalPlaces))
+	);
+}
+
+function getContrastText(background: [number, number, number]) {
+	/* Taken from this StackOverflow answer: https://stackoverflow.com/a/3943023/11588447
+	 * by user @mark-ransom
+	 */
+	return background[0] * 0.299 +
+		background[1] * 0.587 +
+		background[2] * 0.114 >
+		186
+		? "#000000"
+		: "#ffffff";
+}
+
+interface MeterBarSection {
+	label: string;
+	amount: number;
+	renderExtendedText?: (amount: number) => string;
+	colour: [number, number, number];
+}
+
+interface MeterBarProps {
+	className?: string;
+	label: string;
+	sections: MeterBarSection[];
+	renderExtendedText?: (amount: number) => string;
+}
+
+export function MeterBar({
+	sections,
+	className,
+	renderExtendedText,
+	label,
+}: MeterBarProps) {
+	const percentages = getNumbersPercentageOfSum(
+		sections.map((section) => section.amount),
+		2
+	);
+
+	const parsedSections = sections
+		.map((section, i) => ({
+			backgroundColour: section.colour,
+			percentage: percentages[i],
+			renderExtendedText: section.renderExtendedText,
+			label: section.label,
+			amount: section.amount,
+		}))
+		.sort((a, b) => a.amount - b.amount);
+
+	return (
+		<div className={clsx("MicroMeterBar w-full flex flex-col", className)}>
+			<div className="px-20 flex">
+				<h4 className="text-text dark:text-text-d">{label}</h4>
+				<legend className="ml-auto flex space-x-12">
+					{parsedSections.map((section) => (
+						<span className="text-text dark:text-text-d flex items-center">
+							<svg width="10" height="10" className="mr-2">
+								<rect
+									width="10"
+									height="10"
+									rx="2"
+									ry="2"
+									style={{
+										fill: `rgb(${section.backgroundColour[0]}, ${section.backgroundColour[1]}, ${section.backgroundColour[2]})`,
+									}}
+								/>
+							</svg>
+							{section.label}
+						</span>
+					))}
+				</legend>
+			</div>
+			<div className=" h-50 w-full rounded-medium flex items-center overflow-hidden">
+				{parsedSections.map((section) => (
+					<span
+						className="h-full overflow-hidden flex-0 flex flex-nowrap items-center justify-center"
+						style={{
+							backgroundColor: `rgb(${section.backgroundColour[0]}, ${section.backgroundColour[1]}, ${section.backgroundColour[2]})`,
+							width: `${section.percentage}%`,
+
+							color: getContrastText(section.backgroundColour),
+						}}>
+						{`${section.percentage}%`}
+						{section.percentage > 30 &&
+							` (${
+								section.renderExtendedText
+									? section.renderExtendedText(section.amount)
+									: renderExtendedText
+									? renderExtendedText(section.amount)
+									: section.amount
+							})`}
+					</span>
+				))}
+			</div>
+		</div>
+	);
+}

--- a/frontend/src/components/MeterBar.tsx
+++ b/frontend/src/components/MeterBar.tsx
@@ -66,8 +66,10 @@ export function MeterBar({
 			<div className="px-20 flex">
 				<Typography largeness="large">{label}</Typography>
 				<legend className="ml-auto flex space-x-12">
-					{parsedSections.map((section) => (
-						<span className="flex items-center">
+					{parsedSections.map((section, i) => (
+						<span
+							key={section.percentage + "_" + i}
+							className="flex items-center">
 							<svg width="10" height="10" className="mr-2">
 								<rect
 									width="10"
@@ -85,8 +87,9 @@ export function MeterBar({
 				</legend>
 			</div>
 			<div className=" h-50 w-full rounded-medium flex items-center overflow-hidden">
-				{parsedSections.map((section) => (
+				{parsedSections.map((section, i) => (
 					<span
+						key={section.percentage + "_" + i}
 						className="h-full overflow-hidden flex-0 flex flex-nowrap items-center justify-center"
 						style={{
 							backgroundColor: `rgb(${section.backgroundColour[0]}, ${section.backgroundColour[1]}, ${section.backgroundColour[2]})`,

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -9,3 +9,4 @@ export * from "./IconButton";
 export * from "./TextField";
 export * from "./Avatar";
 export * from "./Link";
+export * from "./MeterBar";

--- a/frontend/src/stories/MeterBar.stories.tsx
+++ b/frontend/src/stories/MeterBar.stories.tsx
@@ -12,9 +12,32 @@ export const Basic = () => (
 		<Card className="p-16 w-full">
 			<MeterBar
 				label="Revenue split"
-				showTotalText
-				renderTotalText={(amount) => `Out of $${amount}`}
-				renderExtendedText={(amount) => `$${amount} NZD`}
+				sections={[
+					{
+						label: "Micro",
+						amount: 35.32,
+						colour: [35, 83, 158],
+					},
+					{
+						label: "Charity",
+						amount: 125.45,
+						colour: [158, 35, 72],
+					},
+				]}
+			/>
+		</Card>
+		<Typography>
+			^ Inside a card so that it can be seen against the correct
+			background.
+		</Typography>
+	</>
+);
+
+export const WithMoreThanTwoSections = () => (
+	<>
+		<Card className="p-16 w-full">
+			<MeterBar
+				label="Revenue split"
 				sections={[
 					{
 						label: "Joe",
@@ -29,7 +52,153 @@ export const Basic = () => (
 					{
 						label: "Charity",
 						amount: 125.45,
-						renderExtendedText: (amount) => `$${amount} USD`,
+						colour: [158, 35, 72],
+					},
+				]}
+			/>
+		</Card>
+		<Typography>
+			^ Inside a card so that it can be seen against the correct
+			background.
+		</Typography>
+	</>
+);
+
+export const WithAmounts = () => (
+	<>
+		<Card className="p-16 w-full">
+			<MeterBar
+				label="Revenue split"
+				showAmounts
+				sections={[
+					{
+						label: "Micro",
+						amount: 35.32,
+						colour: [35, 83, 158],
+					},
+					{
+						label: "Charity",
+						amount: 125.45,
+						colour: [158, 35, 72],
+					},
+				]}
+			/>
+		</Card>
+		<Typography>
+			^ Inside a card so that it can be seen against the correct
+			background.
+		</Typography>
+	</>
+);
+
+export const WithAmountRenderers = () => (
+	<>
+		<Card className="p-16 w-full">
+			<MeterBar
+				label="Revenue split"
+				showAmounts
+				renderSectionAmount={(amount) => `$${amount} NZD`}
+				sections={[
+					{
+						label: "Micro",
+						amount: 35.32,
+						colour: [35, 83, 158],
+					},
+					{
+						label: "Charity",
+						amount: 125.45,
+						colour: [158, 35, 72],
+						renderSectionAmount: (amount) => `🎉${amount}!!🎉`,
+					},
+				]}
+			/>
+		</Card>
+		<Typography>
+			^ Inside a card so that it can be seen against the correct
+			background.
+		</Typography>
+	</>
+);
+
+export const WithTotal = () => (
+	<>
+		<Card className="p-16 w-full">
+			<MeterBar
+				label="Revenue split"
+				showTotal
+				sections={[
+					{
+						label: "Micro",
+						amount: 35.32,
+						colour: [35, 83, 158],
+					},
+					{
+						label: "Charity",
+						amount: 125.45,
+						colour: [158, 35, 72],
+					},
+				]}
+			/>
+		</Card>
+		<Typography>
+			^ Inside a card so that it can be seen against the correct
+			background.
+		</Typography>
+	</>
+);
+
+export const WithTotalRenderer = () => (
+	<>
+		<Card className="p-16 w-full">
+			<MeterBar
+				label="Revenue split"
+				showTotal
+				renderTotal={(amount) => `(Out of $${amount} NZD)`}
+				sections={[
+					{
+						label: "Micro",
+						amount: 35.32,
+						colour: [35, 83, 158],
+					},
+					{
+						label: "Charity",
+						amount: 125.45,
+						colour: [158, 35, 72],
+					},
+				]}
+			/>
+		</Card>
+		<Typography>
+			^ Inside a card so that it can be seen against the correct
+			background.
+		</Typography>
+	</>
+);
+
+export const WithEverything = () => (
+	<>
+		<Card className="p-16 w-full">
+			<MeterBar
+				label="Revenue split"
+				showTotal
+				renderTotal={(amount) => `(Out of $${amount} NZD)`}
+				showAmounts
+				renderSectionAmount={(amount) => `$${amount} NZD`}
+				sections={[
+					{
+						label: "Joe",
+						amount: 69,
+						colour: [144, 52, 140],
+					},
+					{
+						label: "Micro",
+						amount: 35.32,
+						colour: [35, 83, 158],
+					},
+					{
+						label: "Charity",
+						amount: 125.45,
+						renderSectionAmount: (amount) => `$${amount} USD`,
 						colour: [158, 35, 72],
 					},
 				]}

--- a/frontend/src/stories/MeterBar.stories.tsx
+++ b/frontend/src/stories/MeterBar.stories.tsx
@@ -1,5 +1,6 @@
+import { Card, MeterBar, Typography } from "../components";
+
 import { Meta } from "@storybook/react";
-import { MeterBar } from "../components";
 
 export default {
 	component: MeterBar,
@@ -7,26 +8,34 @@ export default {
 } as Meta;
 
 export const Basic = () => (
-	<MeterBar
-		label="Revenue split"
-		renderExtendedText={(amount) => `$${amount} NZD`}
-		sections={[
-			{
-				label: "Joe",
-				amount: 69,
-				colour: [144, 52, 140],
-			},
-			{
-				label: "Micro",
-				amount: 35.32,
-				colour: [35, 83, 158],
-			},
-			{
-				label: "Charity",
-				amount: 125.45,
-				renderExtendedText: (amount) => `$${amount} USD`,
-				colour: [158, 35, 72],
-			},
-		]}
-	/>
+	<>
+		<Card className="p-16 w-full">
+			<MeterBar
+				label="Revenue split"
+				renderExtendedText={(amount) => `$${amount} NZD`}
+				sections={[
+					{
+						label: "Joe",
+						amount: 69,
+						colour: [144, 52, 140],
+					},
+					{
+						label: "Micro",
+						amount: 35.32,
+						colour: [35, 83, 158],
+					},
+					{
+						label: "Charity",
+						amount: 125.45,
+						renderExtendedText: (amount) => `$${amount} USD`,
+						colour: [158, 35, 72],
+					},
+				]}
+			/>
+		</Card>
+		<Typography>
+			^ Inside a card so that it can be seen against the correct
+			background.
+		</Typography>
+	</>
 );

--- a/frontend/src/stories/MeterBar.stories.tsx
+++ b/frontend/src/stories/MeterBar.stories.tsx
@@ -1,0 +1,32 @@
+import { Meta } from "@storybook/react";
+import { MeterBar } from "../components";
+
+export default {
+	component: MeterBar,
+	title: "Components/MeterBar",
+} as Meta;
+
+export const Basic = () => (
+	<MeterBar
+		label="Revenue split"
+		renderExtendedText={(amount) => `$${amount} NZD`}
+		sections={[
+			{
+				label: "Joe",
+				amount: 69,
+				colour: [144, 52, 140],
+			},
+			{
+				label: "Micro",
+				amount: 35.32,
+				colour: [35, 83, 158],
+			},
+			{
+				label: "Charity",
+				amount: 125.45,
+				renderExtendedText: (amount) => `$${amount} USD`,
+				colour: [158, 35, 72],
+			},
+		]}
+	/>
+);

--- a/frontend/src/stories/MeterBar.stories.tsx
+++ b/frontend/src/stories/MeterBar.stories.tsx
@@ -12,6 +12,7 @@ export const Basic = () => (
 		<Card className="p-16 w-full">
 			<MeterBar
 				label="Revenue split"
+				renderTotalAmountText={(amount) => `Out of $${amount}`}
 				renderExtendedText={(amount) => `$${amount} NZD`}
 				sections={[
 					{

--- a/frontend/src/stories/MeterBar.stories.tsx
+++ b/frontend/src/stories/MeterBar.stories.tsx
@@ -12,7 +12,8 @@ export const Basic = () => (
 		<Card className="p-16 w-full">
 			<MeterBar
 				label="Revenue split"
-				renderTotalAmountText={(amount) => `Out of $${amount}`}
+				showTotalText
+				renderTotalText={(amount) => `Out of $${amount}`}
 				renderExtendedText={(amount) => `$${amount} NZD`}
 				sections={[
 					{

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -64,6 +64,7 @@ module.exports = {
 			none: "0px",
 			"a-little-bit": "4px",
 			DEFAULT: "8px",
+			medium: "100px",
 			full: "9999px",
 		},
 		strokeWidth: {
@@ -108,6 +109,7 @@ module.exports = {
 			["30"]: "30px",
 			["40"]: "40px",
 			["48"]: "48px",
+			["50"]: "50px",
 			["60"]: "60px",
 			["84"]: "84px",
 			["100"]: "100px",


### PR DESCRIPTION
This is a pull request to add the MeterBar component. I'm making this a pull request instead of committing it directly because there are a lot of things that I'm doing in this component that could be debated. 

For example, people could have reasons for:
- Using some sort of SVG element instead of `<span>` elements for the actual bar,
- Using a normal markup element instead of an SVG `<rect />`s for the colour legend.
Some other things that could also be discussed include:
- API design - Currently everything is done through props, but we could go for a more react-ey approach using composable sub-components.
- Internal methods - Some of the utility functions in the component file could be extracted to their own utility file, either component-specific or for the whole app.

## Preview
Here's a preview of what it currently looks like (inside a card).
Light mode:
![image](https://user-images.githubusercontent.com/46797041/135746730-21333bf3-164f-47e0-9cb6-d0d5c443f568.png)
Dark mode:
![image](https://user-images.githubusercontent.com/46797041/135746737-085a4da6-19d5-45e9-86a6-1338f6f38bc5.png)

## Checklist
  - [x] I have updated Type definitions
  - [x] All the linter checks pass
<!-- If adding components... -->
  - [x] I have updated / added new stories for affected components 

## Waiver
I dedicate any and all copyright interest in this software to the
public domain. I make this dedication for the benefit of the public at
large and to the detriment of my heirs and successors. I intend this
dedication to be an overt act of relinquishment in perpetuity of all
present and future rights to this software under copyright law.
