### PR TITLE
Add gitignore for frontend

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -352,6 +352,3 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
-
-# pnpm
-pnpm-lock.yaml 


### PR DESCRIPTION
Strongly suggest adding a gitignore for the frontend to avoid screwups with pnpm lockfiles

## Checklist
-   [x] I have updated Type definitions.
-   [x] I have run prettier on all the files changed by this commit. (Run separately on the frontend and backend.)
-   [x] All the linter checks pass.
-   [x] I have updated / added new stories for affected components.
<!-- If adding or changing components... -->

## Waiver

I dedicate any and all copyright interest in this software to the
public domain. I make this dedication for the benefit of the public at
large and to the detriment of my heirs and successors. I intend this
dedication to be an overt act of relinquishment in perpetuity of all
present and future rights to this software under copyright law.

 <!-- DO NOT remove the Waiver section!!! -->
